### PR TITLE
Add nicer alt tags for avatar images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4922,9 +4922,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
-      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
@@ -10834,9 +10834,8 @@
       }
     },
     "react-simple-chatbot": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/react-simple-chatbot/-/react-simple-chatbot-0.6.1.tgz",
-      "integrity": "sha512-q9y5GXwBvD+YvLgDVyDuZHYMkrcgIirm1FVV9RkR7XojPmbiX1lCzT6ib8U1M5zh42kTUBRnszXzkAGm9e0K8w==",
+      "version": "github:lazerwalker/react-simple-chatbot#949cf7b70cde9d7cf9956e3be66c7882d761b75a",
+      "from": "github:lazerwalker/react-simple-chatbot",
       "requires": {
         "eslint-config-prettier": "^4.1.0",
         "eslint-plugin-prettier": "^3.0.1",
@@ -10847,29 +10846,6 @@
         "random-id": "0.0.2",
         "react": "^16.4.1",
         "react-dom": "^16.4.1"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        }
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
 		"@testing-library/jest-dom": "^4.2.4",
 		"@testing-library/react": "^9.3.2",
 		"@testing-library/user-event": "^7.1.2",
+		"flatted": "^2.0.2",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"react-scripts": "3.4.1",
-		"react-simple-chatbot": "^0.6.1",
-		"styled-components": "^5.1.0",
-		"flatted": "^2.0.2"
+		"react-simple-chatbot": "github:lazerwalker/react-simple-chatbot",
+		"styled-components": "^5.1.0"
 	},
 	"scripts": {
 		"start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -81,7 +81,7 @@ const steps = [
 const ThemedExample = () => (
 	<ThemeProvider theme={otherFontTheme}>
 		<React.StrictMode>
-			<ChatBot style={chatbox} steps={steps} botAvatar="./chac-chel.png" />
+			<ChatBot style={chatbox} steps={steps} botAvatar="./chac-chel.png" botName="The deity" />
 		</React.StrictMode>
 	</ThemeProvider>
 );


### PR DESCRIPTION
The alt tags for the chat avatars now say "The deity's avatar" and "Your avatar".

For now this means the npm dependency is pointed at my fork of `react-simple-chatbot`, but hopefully we can get this merged upstream. See https://github.com/LucasBassetti/react-simple-chatbot/pull/273